### PR TITLE
bigquery: better handling for json nulls + weird types

### DIFF
--- a/one-table-bigquery.sql
+++ b/one-table-bigquery.sql
@@ -120,8 +120,9 @@ BEGIN
         SAFE_CAST(JSON_VALUE(`_airbyte_data`, '$.updated_at') as TIMESTAMP) as updated_at,
         array_concat(
           CASE
-            -- JSON_VALUE(JSON'{"id": {...}', '$.id') returns NULL, which is obviously wrong.
+            -- JSON_VALUE(JSON'{"id": {...}}', '$.id') returns NULL.
             -- so we use JSON_QUERY instead to check whether there should be a value here.
+            -- If we used json_value, then we would falsely believe that id is unset, and therefore would not populate an error into airbyte_meta.
             WHEN (JSON_QUERY(`_airbyte_data`, '$.id') IS NOT NULL)
               AND (JSON_TYPE(JSON_QUERY(`_airbyte_data`, '$.id') != 'null'))
               -- But we do need JSON_VALUE here to get a SQL value rather than JSON.


### PR DESCRIPTION
I suspect most of this is bigquery-specific. E.g. snowflake has an actual `OBJECT` column type, so try_cast will work fine.

the thing on line 153 is slightly more interesting, in that we're generating a pretty dumb query statement. But I'm hoping bigquery can just autooptimize it, and presumably it's not going to be the performance bottleneck anyway